### PR TITLE
Fix bug in popup display

### DIFF
--- a/0.1/script.js
+++ b/0.1/script.js
@@ -213,7 +213,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 minWidth: popupWidth,
                 minHeight: popupHeight
               })
-              .setLatLng(latlng)
+              .setLatLng(latLng)
               .setContent(markerInfo.content)
               .openOn(map);
                     


### PR DESCRIPTION
## Summary
- fix `latLng` variable name in popup display logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684824e2bcf48323a6e22d9df44cef54